### PR TITLE
newer ubuntu service-name support

### DIFF
--- a/vars/_groovy.yml
+++ b/vars/_groovy.yml
@@ -1,0 +1,3 @@
+# vars file
+---
+rc_local_service_name: rc-local

--- a/vars/_hirsute.yml
+++ b/vars/_hirsute.yml
@@ -1,0 +1,3 @@
+# vars file
+---
+rc_local_service_name: rc-local

--- a/vars/_impish.yml
+++ b/vars/_impish.yml
@@ -1,0 +1,3 @@
+# vars file
+---
+rc_local_service_name: rc-local

--- a/vars/_jammy.yml
+++ b/vars/_jammy.yml
@@ -1,0 +1,3 @@
+# vars file
+---
+rc_local_service_name: rc-local


### PR DESCRIPTION
Newer Ubuntu releases uses different service name for startup. Simply copying the focal default config file solves the missing service error. I included alternative ubuntu releases for the same reason.